### PR TITLE
Add more scripts to run libclang and tensorflow samples on Windows

### DIFF
--- a/libclang/compile_windows.ps1
+++ b/libclang/compile_windows.ps1
@@ -1,0 +1,19 @@
+param(
+  [Parameter(Mandatory=$true, HelpMessage="The path to the llvm installation which include/clang-c")]
+  [string]$clangPath
+)
+
+. ../shared_windows.ps1
+
+$jextract = find-tool("jextract")
+
+& $jextract `
+  -t org.llvm.clang `
+  -I "$clangPath\include" `
+  -I "$clangPath\include\clang-c" `
+  -l libclang `
+  -J-Xmx2G `
+  -J"-Djextract.log.cursors=true" `
+  -J"-Djextract.debug=true" `
+  -- `
+  "$clangPath\include\clang-c\Index.h"

--- a/libclang/run_windows.ps1
+++ b/libclang/run_windows.ps1
@@ -1,0 +1,14 @@
+param(
+  [Parameter(Mandatory=$true, HelpMessage="The path to the llvm installation which include bin/libclang.dll")]
+  [string]$clangPath
+)
+
+. ../shared_windows.ps1
+
+$java = find-tool("java")
+
+& $java `
+  -D"foreign.restricted=permit" `
+  --add-modules jdk.incubator.foreign `
+  -D"java.library.path=$clangPath\bin" `
+  ASTPrinter.java hello.c

--- a/tensorflow/compile_windows.ps1
+++ b/tensorflow/compile_windows.ps1
@@ -1,0 +1,18 @@
+param(
+  [Parameter(Mandatory=$true, HelpMessage="The path to the tensorflow installation which include/tensorflow/c")]
+  [string]$tensorflowPath
+)
+
+. ../shared_windows.ps1
+
+$jextract = find-tool("jextract")
+
+& $jextract `
+  -t org.tensorflow `
+  -I "$tensorflowPath\include" `
+  -l tensorflow `
+  -J-Xmx2G `
+  -J"-Djextract.log.cursors=true" `
+  -J"-Djextract.debug=true" `
+  -- `
+  "$tensorflowPath\include\tensorflow\c\c_api.h"

--- a/tensorflow/run_windows.ps1
+++ b/tensorflow/run_windows.ps1
@@ -1,0 +1,14 @@
+param(
+  [Parameter(Mandatory=$true, HelpMessage="The path to the tensorflow installation, which contains lib/tensorflow.dll")]
+  [string]$tensorflowPath
+)
+
+. ../shared_windows.ps1
+
+$java = find-tool("java")
+
+& $java `
+  -D"foreign.restricted=permit" `
+  --add-modules jdk.incubator.foreign `
+  -D"java.library.path=$tensorflowPath\lib" `
+  TensorflowLoadSavedModel.java saved_mnist_model


### PR DESCRIPTION
Hi,

This PR adds scripts to run the libclang and tensorflow examples on Windows.

I also tried the 'time' example, but it seems like localtime_r is not available in the standard Windows SDK.

Jorn