### PR TITLE
Update windows scripts for new filtering options

### DIFF
--- a/cblas/compile_windows.ps1
+++ b/cblas/compile_windows.ps1
@@ -8,17 +8,8 @@ param(
 $jextract = find-tool("jextract")
 
 & $jextract `
-  -I "$blasPath\include" `
-  --dump-includes 'includes_all.conf' `
-  -- `
-  "$blasPath\include\cblas.h"
-  
-filter_file 'includes_all.conf' 'cblas.h' 'includes_filtered.conf'
-
-& $jextract `
   -t blas `
   -I "$blasPath\include" `
   -l libcblas `
-  '@includes_filtered.conf' `
   -- `
   "$blasPath\include\cblas.h"

--- a/cblas/compile_windows.ps1
+++ b/cblas/compile_windows.ps1
@@ -8,9 +8,17 @@ param(
 $jextract = find-tool("jextract")
 
 & $jextract `
+  -I "$blasPath\include" `
+  --dump-includes 'includes_all.conf' `
+  -- `
+  "$blasPath\include\cblas.h"
+  
+filter_file 'includes_all.conf' 'cblas.h' 'includes_filtered.conf'
+
+& $jextract `
   -t blas `
   -I "$blasPath\include" `
   -l libcblas `
-  --filter 'cblas.h' `
+  '@includes_filtered.conf' `
   -- `
   "$blasPath\include\cblas.h"

--- a/lapack/compile_windows.ps1
+++ b/lapack/compile_windows.ps1
@@ -8,9 +8,17 @@ param(
 $jextract = find-tool("jextract")
 
 & $jextract `
+  -I "$lapackPath\include" `
+  --dump-includes 'includes_all.conf' `
+  -- `
+  "$lapackPath\include\lapacke.h"
+  
+filter_file 'includes_all.conf' 'lapacke.h' 'includes_filtered.conf'
+
+& $jextract `
   -t lapack `
   -I "$lapackPath\include" `
   -l liblapacke `
-  --filter 'lapacke.h' `
+  '@includes_filtered.conf' `
   -- `
   "$lapackPath\include\lapacke.h"

--- a/lapack/compile_windows.ps1
+++ b/lapack/compile_windows.ps1
@@ -8,17 +8,8 @@ param(
 $jextract = find-tool("jextract")
 
 & $jextract `
-  -I "$lapackPath\include" `
-  --dump-includes 'includes_all.conf' `
-  -- `
-  "$lapackPath\include\lapacke.h"
-  
-filter_file 'includes_all.conf' 'lapacke.h' 'includes_filtered.conf'
-
-& $jextract `
   -t lapack `
   -I "$lapackPath\include" `
   -l liblapacke `
-  '@includes_filtered.conf' `
   -- `
   "$lapackPath\include\lapacke.h"

--- a/libcurl/compile_windows.ps1
+++ b/libcurl/compile_windows.ps1
@@ -8,10 +8,19 @@ param(
 $jextract = find-tool("jextract")
 
 & $jextract `
+  -I "$curlpath\include" `
+  -I "$curlpath\include\curl" `
+  --dump-includes 'includes_all.conf' `
+  -- `
+  "$curlpath\include\curl\curl.h"
+  
+filter_file 'includes_all.conf' 'curl' 'includes_filtered.conf'
+
+& $jextract `
   -t org.jextract `
   -I "$curlpath\include" `
   -I "$curlpath\include\curl" `
   -llibcurl `
-  --filter 'curl' `
+  '@includes_filtered.conf' `
   -- `
   "$curlpath\include\curl\curl.h"

--- a/opengl/compile_windows.ps1
+++ b/opengl/compile_windows.ps1
@@ -9,11 +9,18 @@ $jextract = find-tool("jextract")
 
 & $jextract `
   -I "$freeglutPath\include" `
+  --dump-includes 'includes_all.conf' `
+  -- `
+  "$freeglutPath\include\GL\glut.h"
+  
+filter_file 'includes_all.conf' '(GL|GLU)' 'includes_filtered.conf'
+
+& $jextract `
+  -I "$freeglutPath\include" `
   "-l" opengl32 `
   "-l" glu32 `
   "-l" freeglut `
   "-t" "opengl" `
-  --filter 'GL' `
-  --filter 'GLU' `
+  '@includes_filtered.conf' `
   "--" `
   "$freeglutPath\include\GL\glut.h"

--- a/opengl/compile_windows.ps1
+++ b/opengl/compile_windows.ps1
@@ -9,18 +9,9 @@ $jextract = find-tool("jextract")
 
 & $jextract `
   -I "$freeglutPath\include" `
-  --dump-includes 'includes_all.conf' `
-  -- `
-  "$freeglutPath\include\GL\glut.h"
-  
-filter_file 'includes_all.conf' '(GL|GLU)' 'includes_filtered.conf'
-
-& $jextract `
-  -I "$freeglutPath\include" `
   "-l" opengl32 `
   "-l" glu32 `
   "-l" freeglut `
   "-t" "opengl" `
-  '@includes_filtered.conf' `
   "--" `
   "$freeglutPath\include\GL\glut.h"

--- a/shared_windows.ps1
+++ b/shared_windows.ps1
@@ -16,3 +16,7 @@ function find-tool($tool) {
     exit
   }
 }
+
+function filter_file($includes_all, $pattern, $output_file) {  
+  Select-String -Path $includes_all -Pattern $pattern | %{ $_.Line } | Out-File -FilePath $output_file -Encoding ascii
+}


### PR DESCRIPTION
I've kept the filtering options in the script for libcurl, and translated them to the new version, so that the extraction doesn't take too long.

Without filtering:

    Minutes           : 1
    Seconds           : 12
    Milliseconds      : 962
    
With filtering:

    Minutes           : 0
    Seconds           : 8
    Milliseconds      : 66
    
For the other libraries removing the filtering didn't make that much of a difference.

Jorn